### PR TITLE
Fix surface gravity constant to match value used by KER

### DIFF
--- a/Source/Utils.cs
+++ b/Source/Utils.cs
@@ -10,7 +10,7 @@ namespace NearFuturePropulsion
 {
     internal static class Utils
     {
-    
+        public const double GRAVITY = 9.80665;    
 
         // This function loads up some animationstates
         public static AnimationState[] SetUpAnimation(string animationName, Part part)
@@ -113,27 +113,27 @@ namespace NearFuturePropulsion
         public static float FindFlowRate(float thrust, float isp, Propellant fuelPropellant)
         {
             double fuelDensity = PartResourceLibrary.Instance.GetDefinition(fuelPropellant.name).density;
-            double fuelRate = ((thrust * 1000f) / (isp * 9.82d)) / (fuelDensity * 1000f);
+            double fuelRate = ((thrust * 1000f) / (isp * GRAVITY)) / (fuelDensity * 1000f);
             return (float)fuelRate;
         }
 
         public static float FindFlowRate(float thrust, float isp, string fuelPropellant)
         {
             double fuelDensity = PartResourceLibrary.Instance.GetDefinition(fuelPropellant).density;
-            double fuelRate = ((thrust * 1000f) / (isp * 9.82d)) / (fuelDensity * 1000f);
+            double fuelRate = ((thrust * 1000f) / (isp * GRAVITY)) / (fuelDensity * 1000f);
             return (float)fuelRate;
         }
 
         public static float FindIsp(float thrust, float flowRate, Propellant fuelPropellant)
         {
             double fuelDensity = PartResourceLibrary.Instance.GetDefinition(fuelPropellant.name).density;
-            double isp = (((thrust * 1000f) / (9.82d)) / flowRate) / (fuelDensity * 1000f);
+            double isp = (((thrust * 1000f) / (GRAVITY)) / flowRate) / (fuelDensity * 1000f);
             return (float)isp;
         }
         public static float FindIsp(float thrust, float flowRate, string fuelPropellant)
         {
             double fuelDensity = PartResourceLibrary.Instance.GetDefinition(fuelPropellant).density;
-            double isp = (((thrust * 1000f) / (9.82d)) / flowRate) / (fuelDensity * 1000f);
+            double isp = (((thrust * 1000f) / (GRAVITY)) / flowRate) / (fuelDensity * 1000f);
             return (float)isp;
         }
 

--- a/Source/VariableIspEngine.cs
+++ b/Source/VariableIspEngine.cs
@@ -216,7 +216,7 @@ namespace NearFuturePropulsion
         private void RecalculateRatios(float desiredthrust, float desiredisp)
         {
             double fuelDensity = PartResourceLibrary.Instance.GetDefinition(fuelPropellant.name).density;
-            double fuelRate = ((desiredthrust ) / (desiredisp * 9.82d)) ;
+            double fuelRate = ((desiredthrust ) / (desiredisp * Utils.GRAVITY)) ;
             engine.maxFuelFlow = (float)fuelRate;
             fuelRate = fuelRate / fuelDensity;
             float ecRate = EnergyUsage / (float)fuelRate;
@@ -353,14 +353,14 @@ namespace NearFuturePropulsion
         private float FindFlowRate(float thrust, float isp, Propellant fuelPropellant)
         {
             double fuelDensity = PartResourceLibrary.Instance.GetDefinition(fuelPropellant.name).density;
-            double fuelRate = ((thrust * 1000f) / (isp * 9.82d)) / (fuelDensity * 1000f);
+            double fuelRate = ((thrust * 1000f) / (isp * Utils.GRAVITY)) / (fuelDensity * 1000f);
             return (float)fuelRate;
         }
 
         private float FindIsp(float thrust, float flowRate, Propellant fuelPropellant)
         {
             double fuelDensity = PartResourceLibrary.Instance.GetDefinition(fuelPropellant.name).density;
-            double isp = (((thrust * 1000f) / (9.82d)) / flowRate) / (fuelDensity * 1000f);
+            double isp = (((thrust * 1000f) / (Utils.GRAVITY)) / flowRate) / (fuelDensity * 1000f);
             return (float)isp;
         }
 

--- a/Source/VariablePowerEngine.cs
+++ b/Source/VariablePowerEngine.cs
@@ -300,14 +300,14 @@ namespace NearFuturePropulsion
         private float FindFlowRate(float thrust, float isp, Propellant fuelPropellant)
         {
             double fuelDensity = PartResourceLibrary.Instance.GetDefinition(fuelPropellant.name).density;
-            double fuelRate = ((thrust * 1000f) / (isp * 9.82d)) / (fuelDensity * 1000f);
+            double fuelRate = ((thrust * 1000f) / (isp * Utils.GRAVITY)) / (fuelDensity * 1000f);
             return (float)fuelRate;
         }
 
         private float FindIsp(float thrust, float flowRate, Propellant fuelPropellant)
         {
             double fuelDensity = PartResourceLibrary.Instance.GetDefinition(fuelPropellant.name).density;
-            double isp = (((thrust * 1000f) / (9.82d)) / flowRate) / (fuelDensity * 1000f);
+            double isp = (((thrust * 1000f) / (Utils.GRAVITY)) / flowRate) / (fuelDensity * 1000f);
             return (float)isp;
         }
     }


### PR DESCRIPTION
Introduce Utils.GRAVITY with the same value as KER's Units.GRAVITY,
and use it instead of a literal constant everywhere.

Closes ChrisAdderley/NearFuturePropulsion #8