### PR TITLE
Update NFPropulsionISRU.cfg

### DIFF
--- a/GameData/NearFuturePropulsion/Patches/NFPropulsionISRU.cfg
+++ b/GameData/NearFuturePropulsion/Patches/NFPropulsionISRU.cfg
@@ -1,120 +1,31 @@
-// ModuleManager cfg
-
-@PART[ISRU]:FOR[NearFuturePropulsion]
+//by toric5
+//adding NFP ISRU stuff to all mono prop ISRUs
+@PART[*]:HAS[@MODULE[ModuleResourceConverter]:HAS[@OUTPUT_RESOURCE:HAS[#ResourceName[MonoPropellant]]&@INPUT_RESOURCE:HAS[#ResourceName[Ore]]!@OUTPUT_RESOURCE:HAS[#ResourceName[Lithium]]]]:FOR[NearFuturePropulsion]
 {
-   
-	MODULE
-	{
-		name = ModuleResourceConverter
-		ConverterName = Lithium
-		StartActionName = Start ISRU [Li]
-		StopActionName = Stop ISRU [Li]
-		AutoShutdown = true
-		TemperatureModifier
-		{
-			key = 0 100000
-			key = 750 50000
-			key = 1000 10000
-			key = 1250 500
-			key = 2000 50
-			key = 4000 0
-		}
-		 
-		GeneratesHeat = true
-		ThermalEfficiency
-		{
-			key = 0 0 0 0
-			key = 500 0.1 0 0
-			key = 1000 1.0 0 0
-			key = 1250 0.1 0 0
-			key = 3000 0 0 0
-		}
-		DefaultShutoffTemp = .8
-		UseSpecialistBonus = true
-		SpecialistEfficiencyFactor = 0.2
-		SpecialistBonusBase = 0.05
-		Specialty = Engineer
-		EfficiencyBonus = 1
-
-
-		INPUT_RESOURCE
-		{
-			ResourceName = Ore
-			Ratio = 1.0
-			FlowMode = STAGE_PRIORITY_FLOW
-		}
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 50
-		}
-		OUTPUT_RESOURCE
-		{
-			ResourceName = Lithium
-			Ratio = 18.0
-			DumpExcess = false
-			FlowMode = STAGE_PRIORITY_FLOW
-		}
-	}
+   +MODULE[ModuleResourceConverter]:HAS[@OUTPUT_RESOURCE:HAS[#ResourceName[MonoPropellant]]&@INPUT_RESOURCE:HAS[#ResourceName[Ore]]]
+   {
+        @name = ModuleResourceConverter
+        @ConverterName = Lithium
+        @StartActionName = Start ISRU [Li]
+        @StopActionName = Stop ISRU [Li]
+        @Specialty = Engineer
+        @INPUT_RESOURCE:HAS[#ResourceName[Ore]]
+        {
+            @ResourceName = Ore
+            @Ratio *= 2
+            FlowMode = STAGE_PRIORITY_FLOW
+        }
+        @INPUT_RESOURCE:HAS[#ResourceName[ElectricCharge]]
+        {
+            @ResourceName = ElectricCharge
+            @Ratio *= .6
+        }
+        @OUTPUT_RESOURCE:HAS[#ResourceName[MonoPropellant]]
+        {
+            @ResourceName = Lithium
+            @Ratio *= 18
+            @DumpExcess = false
+            FlowMode = STAGE_PRIORITY_FLOW
+        }
+    }
 }
-
-@PART[MiniISRU]:FOR[NearFuturePropulsion]
-{
-    
-	MODULE
-	{
-		name = ModuleResourceConverter
-		ConverterName = Lithium
-		StartActionName = Start ISRU [Li]
-		StopActionName = Stop ISRU [Li]
-		AutoShutdown = true
-		TemperatureModifier
-		{
-			key = 0 50000
-			key = 750 25000
-			key = 1000 5000
-			key = 1250 2500	
-			key = 2000 2500	
-			key = 4000 0
-		}
-		 
-		GeneratesHeat = true
-		ThermalEfficiency
-		{
-			key = 0 0 0 0
-			key = 500 0.9 0 0
-			key = 1000 1.0 0 0
-			key = 1250 0.9 0 0
-			key = 1500 0.5 0 0
-			key = 3000 0.0 0 0 
-		}
-		DefaultShutoffTemp = .8
-		UseSpecialistBonus = true
-		SpecialistEfficiencyFactor = 0.2
-		SpecialistBonusBase = 0.05
-		Specialty = Engineer
-		EfficiencyBonus = 1
-
-
-		INPUT_RESOURCE
-		{
-			ResourceName = Ore
-			Ratio = 5.0
-			FlowMode = STAGE_PRIORITY_FLOW
-		}
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 50
-		}
-		OUTPUT_RESOURCE
-		{
-			ResourceName = Lithium
-			Ratio = 9.0
-			DumpExcess = false
-			FlowMode = STAGE_PRIORITY_FLOW
-		}
-	}
-}
-
-		


### PR DESCRIPTION
first time using git, so i hope i did this right. replaces the mm cfg that adds a lithium refinery to the ISRUs. the old one only added the converters to the stock ones. this cfg looks for any converter that can convert ore into monoprop, and then adds an ore to lithium converter. keeps the same ratios, so the stock two will have the same stats as before, and scales it for third pary ISRUs based on their monoprop converters.
