### PR TITLE
KSP v1.2 electric engine features

### DIFF
--- a/GameData/NearFuturePropulsion/Parts/Engines/ionArgon-0625/ionArgon-0625.cfg
+++ b/GameData/NearFuturePropulsion/Parts/Engines/ionArgon-0625/ionArgon-0625.cfg
@@ -138,10 +138,13 @@ PART
 		minThrust = 0
 		maxThrust = 1.3
 		heatProduction = 9.974
+		EngineType = Electric
 		PROPELLANT
 		{
 			name = ElectricCharge
 			ratio = 0.373060
+			DrawGauge = True
+			minResToLeave = 1.0
 		}
 		PROPELLANT
 		{

--- a/GameData/NearFuturePropulsion/Parts/Engines/ionArgon-125/ionArgon-125.cfg
+++ b/GameData/NearFuturePropulsion/Parts/Engines/ionArgon-125/ionArgon-125.cfg
@@ -133,10 +133,13 @@ PART
 		minThrust = 0
 		maxThrust = 15.45
 		heatProduction = 29.282
+		EngineType = Electric
 		PROPELLANT
 		{
 			name = ElectricCharge
 			ratio = 0.949286
+			DrawGauge = True
+			minResToLeave = 1.0
 		}
 		PROPELLANT
 		{

--- a/GameData/NearFuturePropulsion/Parts/Engines/ionXenon-0625/ionXenon-0625.cfg
+++ b/GameData/NearFuturePropulsion/Parts/Engines/ionXenon-0625/ionXenon-0625.cfg
@@ -121,10 +121,13 @@ PART
 		minThrust = 0
 		maxThrust = 2.3
 		heatProduction = 16.85
+		EngineType = Electric
 		PROPELLANT
 		{
 			name = ElectricCharge
 			ratio = 12.360631
+			DrawGauge = True
+			minResToLeave = 1.0
 		}
 		PROPELLANT
 		{

--- a/GameData/NearFuturePropulsion/Parts/Engines/ionXenon-125/ionXenon-125.cfg
+++ b/GameData/NearFuturePropulsion/Parts/Engines/ionXenon-125/ionXenon-125.cfg
@@ -117,10 +117,13 @@ PART
 		minThrust = 0
 		maxThrust = 4.68
 		heatProduction = 14.946
+		EngineType = Electric
 		PROPELLANT
 		{
 			name = ElectricCharge
 			ratio = 14.5361
+			DrawGauge = True
+			minResToLeave = 1.0
 		}
 		PROPELLANT
 		{

--- a/GameData/NearFuturePropulsion/Parts/Engines/ionXenon-25/ionXenon-25.cfg
+++ b/GameData/NearFuturePropulsion/Parts/Engines/ionXenon-25/ionXenon-25.cfg
@@ -117,10 +117,13 @@ PART
 		minThrust = 0
 		maxThrust = 49.42
 		heatProduction = 57.716
+		EngineType = Electric
 		PROPELLANT
 		{
 			name = ElectricCharge
 			ratio = 47.593417
+			DrawGauge = True
+			minResToLeave = 1.0
 		}
 		PROPELLANT
 		{

--- a/GameData/NearFuturePropulsion/Parts/Engines/mpdt-0625/mpdt-0625.cfg
+++ b/GameData/NearFuturePropulsion/Parts/Engines/mpdt-0625/mpdt-0625.cfg
@@ -135,10 +135,13 @@ PART
 		maxThrust = 46.15
 		fxOffset = 0, 0, 0.0
 		heatProduction = 106.299
+		EngineType = Electric
 		PROPELLANT
 		{
 			name = ElectricCharge
 			ratio = 131.463460
+			DrawGauge = True
+			minResToLeave = 1.0
 		}
 		PROPELLANT
 		{

--- a/GameData/NearFuturePropulsion/Parts/Engines/mpdt-125/mpdt-125.cfg
+++ b/GameData/NearFuturePropulsion/Parts/Engines/mpdt-125/mpdt-125.cfg
@@ -133,10 +133,13 @@ PART
 		minThrust = 0
 		maxThrust = 92.30
 		heatProduction = 87.912
+		EngineType = Electric
 		PROPELLANT
 		{
 			name = ElectricCharge
 			ratio = 192.613670
+			DrawGauge = True
+			minResToLeave = 1.0
 		}
 		PROPELLANT
 		{

--- a/GameData/NearFuturePropulsion/Parts/Engines/mpdt-25/mpdt-25.cfg
+++ b/GameData/NearFuturePropulsion/Parts/Engines/mpdt-25/mpdt-25.cfg
@@ -133,10 +133,13 @@ PART
 		minThrust = 0
 		maxThrust = 237
 		heatProduction = 88.0167
+		EngineType = Electric
 		PROPELLANT
 		{
 			name = ElectricCharge
 			ratio = 251.558486
+			DrawGauge = True
+			minResToLeave = 1.0
 		}
 		PROPELLANT
 		{

--- a/GameData/NearFuturePropulsion/Parts/Engines/pit-0625/pit-0625.cfg
+++ b/GameData/NearFuturePropulsion/Parts/Engines/pit-0625/pit-0625.cfg
@@ -132,11 +132,13 @@ PART
 		minThrust = 0
 		maxThrust = 19.45
 		heatProduction = 69.6535
-
+		EngineType = Electric
 		PROPELLANT
 		{
 			name = ElectricCharge
 			ratio = 0.623977
+			DrawGauge = True
+			minResToLeave = 1.0
 		}
 		PROPELLANT
 		{

--- a/GameData/NearFuturePropulsion/Parts/Engines/pit-125/pit-125.cfg
+++ b/GameData/NearFuturePropulsion/Parts/Engines/pit-125/pit-125.cfg
@@ -130,10 +130,13 @@ PART
 		minThrust = 0
 		maxThrust = 35.35
 		heatProduction = 54.941
+		EngineType = Electric
 		PROPELLANT
 		{
 			name = ElectricCharge
 			ratio = 1.112434
+			DrawGauge = True
+			minResToLeave = 1.0
 		}
 		PROPELLANT
 		{

--- a/GameData/NearFuturePropulsion/Parts/Engines/pit-25/pit-25.cfg
+++ b/GameData/NearFuturePropulsion/Parts/Engines/pit-25/pit-25.cfg
@@ -133,10 +133,13 @@ PART
 		minThrust = 0
 		maxThrust = 54.5
 		heatProduction = 36.68
+		EngineType = Electric
 		PROPELLANT
 		{
 			name = ElectricCharge
 			ratio = 1.764676
+			DrawGauge = True
+			minResToLeave = 1.0
 		}
 		PROPELLANT
 		{

--- a/GameData/NearFuturePropulsion/Parts/Engines/vasimr-0625/vasimr-0625.cfg
+++ b/GameData/NearFuturePropulsion/Parts/Engines/vasimr-0625/vasimr-0625.cfg
@@ -181,10 +181,13 @@ PART
 		minThrust = 0
 		maxThrust = 2.54
 		heatProduction = 28.005
+		EngineType = Electric
 		PROPELLANT
 		{
 			name = ElectricCharge
 			ratio = 0.580196
+			DrawGauge = True
+			minResToLeave = 1.0
 		}
 		PROPELLANT
 		{
@@ -212,10 +215,13 @@ PART
 		minThrust = 0
 		maxThrust = 4.14
 		heatProduction = 18.674
+		EngineType = Electric
 		PROPELLANT
 		{
 			name = ElectricCharge
 			ratio = 14.084580
+			DrawGauge = True
+			minResToLeave = 1.0
 		}
 		PROPELLANT
 		{

--- a/GameData/NearFuturePropulsion/Parts/Engines/vasimr-125/vasimr-125.cfg
+++ b/GameData/NearFuturePropulsion/Parts/Engines/vasimr-125/vasimr-125.cfg
@@ -177,10 +177,13 @@ PART
 		minThrust = 0
 		maxThrust = 9.45
 		heatProduction = 37.567
+		EngineType = Electric
 		PROPELLANT
 		{
 			name = ElectricCharge
 			ratio = 0.6653115
+			DrawGauge = True
+			minResToLeave = 1.0
 		}
 		PROPELLANT
 		{
@@ -208,10 +211,13 @@ PART
 		minThrust = 0
 		maxThrust = 14.90
 		heatProduction = 25.047
+		EngineType = Electric
 		PROPELLANT
 		{
 			name = ElectricCharge
 			ratio = 17.082340
+			DrawGauge = True
+			minResToLeave = 1.0
 		}
 		PROPELLANT
 		{

--- a/GameData/NearFuturePropulsion/Parts/Engines/vasimr-25/vasimr-25.cfg
+++ b/GameData/NearFuturePropulsion/Parts/Engines/vasimr-25/vasimr-25.cfg
@@ -175,10 +175,13 @@ PART
 		minThrust = 0
 		maxThrust = 43.85
 		heatProduction = 64.608
+		EngineType = Electric
 		PROPELLANT
 		{
 			name = ElectricCharge
 			ratio = 0.7577875
+			DrawGauge = True
+			minResToLeave = 1.0
 		}
 		PROPELLANT
 		{
@@ -206,10 +209,13 @@ PART
 		minThrust = 0
 		maxThrust = 67.25
 		heatProduction = 43.073
+		EngineType = Electric
 		PROPELLANT
 		{
 			name = ElectricCharge
 			ratio = 20.408180
+			DrawGauge = True
+			minResToLeave = 1.0
 		}
 		PROPELLANT
 		{


### PR DESCRIPTION
Adding the new EngineType and minResToLeave fields to each engine, as well as enabling gauge drawing for Ec, analoguous to the stock Dawn engine. Includes soft-deprecated parts, because it really wasn't that much extra effort.

Requires testing if plugin engines (PITs and VASIMRs) correctly obey minResToLeave.