### PR TITLE
RCS block cost diversification suggestion

### DIFF
--- a/GameData/NearFuturePropulsion/Parts/RCS/rcsblock-electric/rcsblock-gridded-01.cfg
+++ b/GameData/NearFuturePropulsion/Parts/RCS/rcsblock-electric/rcsblock-gridded-01.cfg
@@ -24,8 +24,8 @@ PART
 
 	// --- editor parameters ---
 	TechRequired = ionPropulsion
-	entryCost = 4550
-	cost = 850
+	entryCost = 5300
+	cost = 600
 	category = Control
 	subcategory = 0
 	title = IW-201 Gridded Ion Thruster

--- a/GameData/NearFuturePropulsion/Parts/RCS/rcsblock-electric/rcsblock-hall-01.cfg
+++ b/GameData/NearFuturePropulsion/Parts/RCS/rcsblock-electric/rcsblock-hall-01.cfg
@@ -25,7 +25,7 @@ PART
 	// --- editor parameters ---
 	TechRequired = ionPropulsion
 	entryCost = 4550
-	cost = 850
+	cost = 400
 	category = Control
 	subcategory = 0
 	title = SPZ-5167 Hall Effect RCS Thruster

--- a/GameData/NearFuturePropulsion/Parts/RCS/rcsblock-electric/rcsblock-mpdt-quad-01.cfg
+++ b/GameData/NearFuturePropulsion/Parts/RCS/rcsblock-electric/rcsblock-mpdt-quad-01.cfg
@@ -24,8 +24,8 @@ PART
 
 	// --- editor parameters ---
 	TechRequired = ionPropulsion
-	entryCost = 2550
-	cost = 250
+	entryCost = 6000
+	cost = 1350
 	category = Control
 	subcategory = 0
 	title = LiFt-4 Magnetoplasmadynamic RCS Block

--- a/GameData/NearFuturePropulsion/Parts/RCS/rcsblock-electric/rcsblock-mpdt-quint-01.cfg
+++ b/GameData/NearFuturePropulsion/Parts/RCS/rcsblock-electric/rcsblock-mpdt-quint-01.cfg
@@ -24,8 +24,8 @@ PART
 
 	// --- editor parameters ---
 	TechRequired = ionPropulsion
-	entryCost = 2550
-	cost = 250
+	entryCost = 6000
+	cost = 1500
 	category = Control
 	subcategory = 0
 	title = LiFt-5 Magnetoplasmadynamic RCS Block

--- a/GameData/NearFuturePropulsion/Parts/RCS/rcsblock-electric/rcsblock-mpdt-single-01.cfg
+++ b/GameData/NearFuturePropulsion/Parts/RCS/rcsblock-electric/rcsblock-mpdt-single-01.cfg
@@ -24,8 +24,8 @@ PART
 
 	// --- editor parameters ---
 	TechRequired = ionPropulsion
-	entryCost = 2550
-	cost = 250
+	entryCost = 6000
+	cost = 500
 	category = Control
 	subcategory = 0
 	title = LiFt-1 Magnetoplasmadynamic RCS Thruster

--- a/GameData/NearFuturePropulsion/Parts/RCS/rcsblock-electric/rcsblock-mpdt-triple-01.cfg
+++ b/GameData/NearFuturePropulsion/Parts/RCS/rcsblock-electric/rcsblock-mpdt-triple-01.cfg
@@ -24,8 +24,8 @@ PART
 
 	// --- editor parameters ---
 	TechRequired = ionPropulsion
-	entryCost = 2550
-	cost = 250
+	entryCost = 6000
+	cost = 1100
 	category = Control
 	subcategory = 0
 	title = LiFt-3 Magnetoplasmadynamic RCS Block

--- a/GameData/NearFuturePropulsion/Parts/RCS/rcsblock-electric/rcsblock-pulsedplasma-01.cfg
+++ b/GameData/NearFuturePropulsion/Parts/RCS/rcsblock-electric/rcsblock-pulsedplasma-01.cfg
@@ -25,7 +25,7 @@ PART
 	// --- editor parameters ---
 	TechRequired = ionPropulsion
 	entryCost = 2550
-	cost = 250
+	cost = 200
 	category = Control
 	subcategory = 0
 	title = KO-1 Pulsed Plasma RCS Thruster


### PR DESCRIPTION
...so that the PPTx1 thruster, billed as cheap, doesn't cost the same to unlock and to use as the MPDTx5 block ;)