### PR TITLE
Add lithium production to PlanetaryBaseInc ISRU

### DIFF
--- a/GameData/NearFuturePropulsion/Patches/NFPropulsionISRU.cfg
+++ b/GameData/NearFuturePropulsion/Patches/NFPropulsionISRU.cfg
@@ -118,4 +118,63 @@
 	}
 }
 
+// K&K Planetary ISRU from Nils277's Kerbal Planetary Base Systems
+@PART[KKAOSS_ISRU_g]:NEEDS[PlanetaryBaseInc]:FOR[NearFuturePropulsion]
+{
+   
+	MODULE
+	{
+		name = ModuleResourceConverter
+		ConverterName = Lithium
+		StartActionName = Start ISRU [Li]
+		StopActionName = Stop ISRU [Li]
+		AutoShutdown = true
+		TemperatureModifier
+		{
+			key = 0 100000
+			key = 750 50000
+			key = 1000 10000
+			key = 1250 500
+			key = 2000 50
+			key = 4000 0
+		}
+		 
+		GeneratesHeat = true
+		ThermalEfficiency
+		{
+			key = 0 0 0 0
+			key = 500 0.1 0 0
+			key = 1000 1.0 0 0
+			key = 1250 0.1 0 0
+			key = 3000 0 0 0
+		}
+		DefaultShutoffTemp = .8
+		UseSpecialistBonus = true
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+
+
+		INPUT_RESOURCE
+		{
+			ResourceName = Ore
+			Ratio = 0.8
+			FlowMode = STAGE_PRIORITY_FLOW
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 40
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Lithium
+			Ratio = 14.4
+			DumpExcess = false
+			FlowMode = STAGE_PRIORITY_FLOW
+		}
+	}
+}
+
 		


### PR DESCRIPTION
This adds lithium production to the planetary ISRU part from [Kerbal Planetary Base Systems](http://forum.kerbalspaceprogram.com/index.php?/topic/133606-12/).  It's not as general as #31 (which aims to support *all* mods' ISRU parts), but it's also more straightforward and shouldn't lead to unintended interactions with other mods.

Conversion rate is 80% of stock ISRU, same as for the planetary version's other resource converters.