### PR TITLE
Give NF parts PhysicsSignificance = 1

### DIFF
--- a/GameData/NearFuturePropulsion/Parts/RCS/rcsblock-electric/rcsblock-gridded-01.cfg
+++ b/GameData/NearFuturePropulsion/Parts/RCS/rcsblock-electric/rcsblock-gridded-01.cfg
@@ -43,6 +43,7 @@ PART
 	angularDrag = 2
 	crashTolerance = 15
 	maxTemp = 1200
+	PhysicsSignificance = 1
 
 	EFFECTS
 	{

--- a/GameData/NearFuturePropulsion/Parts/RCS/rcsblock-electric/rcsblock-hall-01.cfg
+++ b/GameData/NearFuturePropulsion/Parts/RCS/rcsblock-electric/rcsblock-hall-01.cfg
@@ -44,6 +44,7 @@ PART
 	angularDrag = 2
 	crashTolerance = 15
 	maxTemp = 1700
+	PhysicsSignificance = 1
 
 	EFFECTS
 	{

--- a/GameData/NearFuturePropulsion/Parts/RCS/rcsblock-electric/rcsblock-mpdt-quad-01.cfg
+++ b/GameData/NearFuturePropulsion/Parts/RCS/rcsblock-electric/rcsblock-mpdt-quad-01.cfg
@@ -45,6 +45,7 @@ PART
 	angularDrag = 2
 	crashTolerance = 15
 	maxTemp = 1700
+	PhysicsSignificance = 1
 
 	EFFECTS
 	{

--- a/GameData/NearFuturePropulsion/Parts/RCS/rcsblock-electric/rcsblock-mpdt-quint-01.cfg
+++ b/GameData/NearFuturePropulsion/Parts/RCS/rcsblock-electric/rcsblock-mpdt-quint-01.cfg
@@ -45,6 +45,7 @@ PART
 	angularDrag = 2
 	crashTolerance = 15
 	maxTemp = 1700
+	PhysicsSignificance = 1
 
 	EFFECTS
 	{

--- a/GameData/NearFuturePropulsion/Parts/RCS/rcsblock-electric/rcsblock-mpdt-single-01.cfg
+++ b/GameData/NearFuturePropulsion/Parts/RCS/rcsblock-electric/rcsblock-mpdt-single-01.cfg
@@ -45,6 +45,7 @@ PART
 	angularDrag = 2
 	crashTolerance = 15
 	maxTemp = 1700
+	PhysicsSignificance = 1
 
 	EFFECTS
 	{

--- a/GameData/NearFuturePropulsion/Parts/RCS/rcsblock-electric/rcsblock-mpdt-triple-01.cfg
+++ b/GameData/NearFuturePropulsion/Parts/RCS/rcsblock-electric/rcsblock-mpdt-triple-01.cfg
@@ -45,6 +45,7 @@ PART
 	angularDrag = 2
 	crashTolerance = 15
 	maxTemp = 1700
+	PhysicsSignificance = 1
 
 	EFFECTS
 	{

--- a/GameData/NearFuturePropulsion/Parts/RCS/rcsblock-electric/rcsblock-pulsedplasma-01.cfg
+++ b/GameData/NearFuturePropulsion/Parts/RCS/rcsblock-electric/rcsblock-pulsedplasma-01.cfg
@@ -44,6 +44,7 @@ PART
 	angularDrag = 2
 	crashTolerance = 15
 	maxTemp = 1700
+	PhysicsSignificance = 1
 
 	EFFECTS
 	{

--- a/GameData/NearFuturePropulsion/Parts/Resources/gasspectrometer-01/gasspectrometer-01.cfg
+++ b/GameData/NearFuturePropulsion/Parts/Resources/gasspectrometer-01/gasspectrometer-01.cfg
@@ -27,10 +27,8 @@ PART
 	crashTolerance = 8
 	breakingForce = 200
 	breakingTorque = 200
-
 	maxTemp = 1500
-
-
+	PhysicsSignificance = 1
 
 	MODULE
 	{


### PR DESCRIPTION
I was playing around with the Near Future mods, making myself a nice interplanetary mothership (and really loving the Magnetoplasmadynamic engines!) and I noticed that the Near Future RCS thruster parts did not have PhysicsSignificance = 1 set, while all the stock RCS thruster parts do.

It seems the stock game makes RCS ports and other such low-mass parts "physicsless" for performance reasons, and I decided to test if this was in fact the case. I set up a huge ship with 296 parts, 94 of them being NF RCS thrusters. When changing them to "PhysicsSignificance = 1", I observed a 10% improvement in physics frame updating as measured by the MemGraph mod.

As such, I've given all the RCS blocks across the NF mods PhysicsSignificance = 1, as well as the Atmospheric Sounder part and the radially-attachable Capacitors from NF Electrical, as they are very similar to the stock science experiment parts and radial batteries, respectively, which are also "physicsless".

(This message accompanies three pull requests for NF Propulsion, NF Electrical, and NF Spacecraft.)