### PR TITLE
Fix ionXenon-125 plume

### DIFF
--- a/GameData/NearFuturePropulsion/Parts/Engines/ionXenon-125/ionXenon-125.cfg
+++ b/GameData/NearFuturePropulsion/Parts/Engines/ionXenon-125/ionXenon-125.cfg
@@ -79,7 +79,7 @@ PART
 			}
 			MODEL_MULTI_PARTICLE
 			{
-				modelName = NearFuturePropulsion/FX/nextplume
+				modelName = NearFuturePropulsion/FX/ionXenon0625-01-plume
 				transformName = thrustTransform
 				emission = 0.0 0.0
 				emission = 0.01 0.1


### PR DESCRIPTION
Nextplume.mu is missing in the NearFuturePropulsion/FX/ folder, using ionXenon0625-01-plume also looks better.