### PR TITLE
Target correct module name for engine lighting patch

### DIFF
--- a/GameData/NearFuturePropulsion/Patches/NFPropulsionEngineLight.cfg
+++ b/GameData/NearFuturePropulsion/Patches/NFPropulsionEngineLight.cfg
@@ -2,77 +2,77 @@
 // Engines
 @PART[ionXenon-0625-1]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 @PART[ionXenon-0625-2]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 @PART[ionXenon-0625-3]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 @PART[ionXenon-125]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 @PART[ionXenon-25]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 
 @PART[ionArgon-0625]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 @PART[ionArgon-0625-2]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 @PART[ionArgon-0625-3]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 @PART[ionArgon-125]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 
 @PART[pit-25]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 @PART[pit-125]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 @PART[pit-0625]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 
 @PART[mpdt-25]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 @PART[mpdt-125]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 @PART[mpdt-0625]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 
 @PART[vasimr-25]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 @PART[vasimr-125]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 @PART[vasimr-0625]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }


### PR DESCRIPTION
The extant NFP engine light patches delete the default engine light modules probably because they are too bright for these electric engines.

Since the module name has changed from ``tjs_EngineLight`` to ``EngineLightEffect`` in LGG's Engine Lighting Relit, this PR updates the patch accordingly. 

Maybe someone will make proper patches with matching colours and intenity at some point but for now this avoids excessively bright lighting when EL is installed.