### PR TITLE
Add custom engine lighting configs for Engine lighting relit

### DIFF
--- a/GameData/NearFuturePropulsion/Patches/NFPropulsionEngineLight.cfg
+++ b/GameData/NearFuturePropulsion/Patches/NFPropulsionEngineLight.cfg
@@ -2,77 +2,77 @@
 // Engines
 @PART[ionXenon-0625-1]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 @PART[ionXenon-0625-2]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 @PART[ionXenon-0625-3]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 @PART[ionXenon-125]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 @PART[ionXenon-25]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 
 @PART[ionArgon-0625]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 @PART[ionArgon-0625-2]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 @PART[ionArgon-0625-3]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 @PART[ionArgon-125]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 
 @PART[pit-25]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 @PART[pit-125]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 @PART[pit-0625]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 
 @PART[mpdt-25]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 @PART[mpdt-125]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 @PART[mpdt-0625]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 
 @PART[vasimr-25]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 @PART[vasimr-125]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }
 @PART[vasimr-0625]:AFTER[EngineLight]
 {
-	!MODULE[tjs_EngineLight] {}
+	!MODULE[EngineLightEffect] {}
 }

--- a/GameData/NearFuturePropulsion/Patches/NFPropulsionEngineLight.cfg
+++ b/GameData/NearFuturePropulsion/Patches/NFPropulsionEngineLight.cfg
@@ -243,15 +243,15 @@
 			%engineEmissiveMultiplier = 1 // 1.33 //scale emissive brightness
 			%jitterMultiplier = 0.5 //0.1 // controls main engine light flicker intensity
 			%lightFadeCoefficient = 0.7
-			%lightPower = .25
-			%lightRange = 3 // 9.0 small engine
+			%lightPower = 0.5
+			%lightRange = 7 // 9.0 small engine
 
 			%multiplierOnIva = .25 //  0.5 ? // scale main engine brightness when in IVA
 
 			// main engine light colour
 			%exhaustRed = 1 //
-      %exhaustGreen = 0.5 //0.55 //
-      %exhaustBlue = 0.5 //
+      %exhaustGreen = 0.3 //0.55 //
+      %exhaustBlue = 0.3 //
 
 			%emissiveOffsetZ = #$../node_stack_bottom[1]$
 			@emissiveOffsetZ *=-0.67
@@ -268,15 +268,15 @@
 			%engineEmissiveMultiplier = 1 // 1.33 //scale emissive brightness
 			%jitterMultiplier = 0.5 //0.1 // controls main engine light flicker intensity
 			%lightFadeCoefficient = 0.7
-			%lightPower = .25
-			%lightRange = 3 // 9.0 small engine
+			%lightPower = 0.5
+			%lightRange = 7 // 9.0 small engine
 
 			%multiplierOnIva = .25 //  0.5 ? // scale main engine brightness when in IVA
 
 			// main engine light colour
 			%exhaustRed = 1 //
-      %exhaustGreen = 0.5 //0.55 //
-      %exhaustBlue = 0.5 //
+      %exhaustGreen = 0.3 //0.55 //
+      %exhaustBlue = 0.3 //
 
 			%emissiveOffsetZ = #$../node_stack_bottom[1]$
 			@emissiveOffsetZ *=-0.67
@@ -293,15 +293,15 @@
 			%engineEmissiveMultiplier = 1 // 1.33 //scale emissive brightness
 			%jitterMultiplier = 0.5 //0.1 // controls main engine light flicker intensity
 			%lightFadeCoefficient = 0.7
-			%lightPower = .25
-			%lightRange = 3 // 9.0 small engine
+			%lightPower = 0.5
+			%lightRange = 5 // 9.0 small engine
 
 			%multiplierOnIva = .25 //  0.5 ? // scale main engine brightness when in IVA
 
 			// main engine light colour
 			%exhaustRed = 1 //
-      %exhaustGreen = 0.5 //0.55 //
-      %exhaustBlue = 0.5 //
+      %exhaustGreen = 0.3 //0.55 //
+      %exhaustBlue = 0.3 //
 
 			%emissiveOffsetZ = #$../node_stack_bottom[1]$
 			@emissiveOffsetZ *=-0.67

--- a/GameData/NearFuturePropulsion/Patches/NFPropulsionEngineLight.cfg
+++ b/GameData/NearFuturePropulsion/Patches/NFPropulsionEngineLight.cfg
@@ -1,78 +1,390 @@
+//Engine lighting configs by Zorg
 
 // Engines
-@PART[ionXenon-0625-1]:AFTER[EngineLight]
+@PART[ionXenon-0625]:AFTER[EngineLight]
 {
-	!MODULE[EngineLightEffect] {}
+	@MODULE[EngineLightEffect]
+	{
+			//name = EngineLightEffect
+			%enableEmissiveLight = false // engines with no emissive will shut this off automatically
+			%engineEmissiveMultiplier = 1 // 1.33 //scale emissive brightness
+			%jitterMultiplier = 0.5 //0.1 // controls main engine light flicker intensity
+			%lightFadeCoefficient = 0.7
+			%lightPower = .25
+			%lightRange = 3 // 9.0 small engine
+
+			%multiplierOnIva = .25 //  0.5 ? // scale main engine brightness when in IVA
+
+			// main engine light colour
+			%exhaustRed = 0.3 //
+			%exhaustGreen = 0.7 //0.55 //
+			%exhaustBlue = 1 //
+
+			%emissiveOffsetZ = #$../node_stack_bottom[1]$
+			@emissiveOffsetZ *=-0.67
+			%exhaustOffsetZ = #$../node_stack_bottom[1]$
+		 @exhaustOffsetZ *= -1.1
+	}
 }
 @PART[ionXenon-0625-2]:AFTER[EngineLight]
 {
-	!MODULE[EngineLightEffect] {}
+	@MODULE[EngineLightEffect]
+	{
+			//name = EngineLightEffect
+			%enableEmissiveLight = false // engines with no emissive will shut this off automatically
+			%engineEmissiveMultiplier = 1 // 1.33 //scale emissive brightness
+			%jitterMultiplier = 0.5 //0.1 // controls main engine light flicker intensity
+			%lightFadeCoefficient = 0.7
+			%lightPower = .25
+			%lightRange = 3 // 9.0 small engine
+
+			%multiplierOnIva = .25 //  0.5 ? // scale main engine brightness when in IVA
+
+			// main engine light colour
+			%exhaustRed = 0.3 //
+			%exhaustGreen = 0.7 //0.55 //
+			%exhaustBlue = 1 //
+
+			%emissiveOffsetZ = #$../node_stack_bottom[1]$
+			@emissiveOffsetZ *=-0.67
+			%exhaustOffsetZ = #$../node_stack_bottom[1]$
+		 @exhaustOffsetZ *= -1.1
+	}
 }
 @PART[ionXenon-0625-3]:AFTER[EngineLight]
 {
-	!MODULE[EngineLightEffect] {}
+	@MODULE[EngineLightEffect]
+	{
+			//name = EngineLightEffect
+			%enableEmissiveLight = false // engines with no emissive will shut this off automatically
+			%engineEmissiveMultiplier = 1 // 1.33 //scale emissive brightness
+			%jitterMultiplier = 0.5 //0.1 // controls main engine light flicker intensity
+			%lightFadeCoefficient = 0.7
+			%lightPower = .25
+			%lightRange = 3 // 9.0 small engine
+
+			%multiplierOnIva = .25 //  0.5 ? // scale main engine brightness when in IVA
+
+			// main engine light colour
+			%exhaustRed = 0.3 //
+			%exhaustGreen = 0.7 //0.55 //
+			%exhaustBlue = 1 //
+
+			%emissiveOffsetZ = #$../node_stack_bottom[1]$
+			@emissiveOffsetZ *=-0.67
+			%exhaustOffsetZ = #$../node_stack_bottom[1]$
+		 @exhaustOffsetZ *= -1.1
+	}
 }
-@PART[ionXenon-125]:AFTER[EngineLight]
-{
-	!MODULE[EngineLightEffect] {}
-}
-@PART[ionXenon-25]:AFTER[EngineLight]
-{
-	!MODULE[EngineLightEffect] {}
-}
+
 
 @PART[ionArgon-0625]:AFTER[EngineLight]
 {
-	!MODULE[EngineLightEffect] {}
+	@MODULE[EngineLightEffect]
+	{
+			//name = EngineLightEffect
+			%enableEmissiveLight = false // engines with no emissive will shut this off automatically
+			%engineEmissiveMultiplier = 1 // 1.33 //scale emissive brightness
+			%jitterMultiplier = 0.5 //0.1 // controls main engine light flicker intensity
+			%lightFadeCoefficient = 0.7
+			%lightPower = .25
+			%lightRange = 3 // 9.0 small engine
+
+			%multiplierOnIva = .25 //  0.5 ? // scale main engine brightness when in IVA
+
+			// main engine light colour
+			%exhaustRed = 0.8 //
+      %exhaustGreen = 0.5 //0.55 //
+      %exhaustBlue = 1 //
+
+			%emissiveOffsetZ = #$../node_stack_bottom[1]$
+			@emissiveOffsetZ *=-0.67
+			%exhaustOffsetZ = #$../node_stack_bottom[1]$
+		 @exhaustOffsetZ *= -1.1
+	}
 }
 @PART[ionArgon-0625-2]:AFTER[EngineLight]
 {
-	!MODULE[EngineLightEffect] {}
+	@MODULE[EngineLightEffect]
+	{
+			//name = EngineLightEffect
+			%enableEmissiveLight = false // engines with no emissive will shut this off automatically
+			%engineEmissiveMultiplier = 1 // 1.33 //scale emissive brightness
+			%jitterMultiplier = 0.5 //0.1 // controls main engine light flicker intensity
+			%lightFadeCoefficient = 0.7
+			%lightPower = .25
+			%lightRange = 3 // 9.0 small engine
+
+			%multiplierOnIva = .25 //  0.5 ? // scale main engine brightness when in IVA
+
+			// main engine light colour
+			%exhaustRed = 0.8 //
+      %exhaustGreen = 0.5 //0.55 //
+      %exhaustBlue = 1 //
+
+			%emissiveOffsetZ = #$../node_stack_bottom[1]$
+			@emissiveOffsetZ *=-0.67
+			%exhaustOffsetZ = #$../node_stack_bottom[1]$
+		 @exhaustOffsetZ *= -1.1
+	}
 }
 @PART[ionArgon-0625-3]:AFTER[EngineLight]
 {
-	!MODULE[EngineLightEffect] {}
+	@MODULE[EngineLightEffect]
+	{
+			//name = EngineLightEffect
+			%enableEmissiveLight = false // engines with no emissive will shut this off automatically
+			%engineEmissiveMultiplier = 1 // 1.33 //scale emissive brightness
+			%jitterMultiplier = 0.5 //0.1 // controls main engine light flicker intensity
+			%lightFadeCoefficient = 0.7
+			%lightPower = .25
+			%lightRange = 3 // 9.0 small engine
+
+			%multiplierOnIva = .25 //  0.5 ? // scale main engine brightness when in IVA
+
+			// main engine light colour
+			%exhaustRed = 0.8 //
+      %exhaustGreen = 0.5 //0.55 //
+      %exhaustBlue = 1 //
+
+			%emissiveOffsetZ = #$../node_stack_bottom[1]$
+			@emissiveOffsetZ *=-0.67
+			%exhaustOffsetZ = #$../node_stack_bottom[1]$
+		 @exhaustOffsetZ *= -1.1
+	}
 }
-@PART[ionArgon-125]:AFTER[EngineLight]
-{
-	!MODULE[EngineLightEffect] {}
-}
+
+
 
 @PART[pit-25]:AFTER[EngineLight]
 {
-	!MODULE[EngineLightEffect] {}
+	@MODULE[EngineLightEffect]
+	{
+			//name = EngineLightEffect
+			%enableEmissiveLight = false // engines with no emissive will shut this off automatically
+			%engineEmissiveMultiplier = 1 // 1.33 //scale emissive brightness
+			%jitterMultiplier = 0.5 //0.1 // controls main engine light flicker intensity
+			%lightFadeCoefficient = 0.7
+			%lightPower = .25
+			%lightRange = 3 // 9.0 small engine
+
+			%multiplierOnIva = .25 //  0.5 ? // scale main engine brightness when in IVA
+
+			// main engine light colour
+			%exhaustRed = 0.8 //
+      %exhaustGreen = 0.5 //0.55 //
+      %exhaustBlue = 1 //
+
+			%emissiveOffsetZ = #$../node_stack_bottom[1]$
+			@emissiveOffsetZ *=-0.67
+			%exhaustOffsetZ = #$../node_stack_bottom[1]$
+		 @exhaustOffsetZ *= -1.1
+	}
 }
 @PART[pit-125]:AFTER[EngineLight]
 {
-	!MODULE[EngineLightEffect] {}
+	@MODULE[EngineLightEffect]
+	{
+			//name = EngineLightEffect
+			%enableEmissiveLight = false // engines with no emissive will shut this off automatically
+			%engineEmissiveMultiplier = 1 // 1.33 //scale emissive brightness
+			%jitterMultiplier = 0.5 //0.1 // controls main engine light flicker intensity
+			%lightFadeCoefficient = 0.7
+			%lightPower = .25
+			%lightRange = 3 // 9.0 small engine
+
+			%multiplierOnIva = .25 //  0.5 ? // scale main engine brightness when in IVA
+
+			// main engine light colour
+			%exhaustRed = 0.8 //
+      %exhaustGreen = 0.5 //0.55 //
+      %exhaustBlue = 1 //
+
+			%emissiveOffsetZ = #$../node_stack_bottom[1]$
+			@emissiveOffsetZ *=-0.67
+			%exhaustOffsetZ = #$../node_stack_bottom[1]$
+		 @exhaustOffsetZ *= -1.1
+	}
 }
 @PART[pit-0625]:AFTER[EngineLight]
 {
-	!MODULE[EngineLightEffect] {}
+	@MODULE[EngineLightEffect]
+	{
+			//name = EngineLightEffect
+			%enableEmissiveLight = false // engines with no emissive will shut this off automatically
+			%engineEmissiveMultiplier = 1 // 1.33 //scale emissive brightness
+			%jitterMultiplier = 0.5 //0.1 // controls main engine light flicker intensity
+			%lightFadeCoefficient = 0.7
+			%lightPower = .25
+			%lightRange = 3 // 9.0 small engine
+
+			%multiplierOnIva = .25 //  0.5 ? // scale main engine brightness when in IVA
+
+			// main engine light colour
+			%exhaustRed = 0.8 //
+      %exhaustGreen = 0.5 //0.55 //
+      %exhaustBlue = 1 //
+
+			%emissiveOffsetZ = #$../node_stack_bottom[1]$
+			@emissiveOffsetZ *=-0.67
+			%exhaustOffsetZ = #$../node_stack_bottom[1]$
+		 @exhaustOffsetZ *= -1.1
+	}
 }
+
+
 
 @PART[mpdt-25]:AFTER[EngineLight]
 {
-	!MODULE[EngineLightEffect] {}
+	@MODULE[EngineLightEffect]
+	{
+			//name = EngineLightEffect
+			%enableEmissiveLight = false // engines with no emissive will shut this off automatically
+			%engineEmissiveMultiplier = 1 // 1.33 //scale emissive brightness
+			%jitterMultiplier = 0.5 //0.1 // controls main engine light flicker intensity
+			%lightFadeCoefficient = 0.7
+			%lightPower = .25
+			%lightRange = 3 // 9.0 small engine
+
+			%multiplierOnIva = .25 //  0.5 ? // scale main engine brightness when in IVA
+
+			// main engine light colour
+			%exhaustRed = 1 //
+      %exhaustGreen = 0.5 //0.55 //
+      %exhaustBlue = 0.5 //
+
+			%emissiveOffsetZ = #$../node_stack_bottom[1]$
+			@emissiveOffsetZ *=-0.67
+			%exhaustOffsetZ = #$../node_stack_bottom[1]$
+		 @exhaustOffsetZ *= -1.1
+	}
 }
 @PART[mpdt-125]:AFTER[EngineLight]
 {
-	!MODULE[EngineLightEffect] {}
+	@MODULE[EngineLightEffect]
+	{
+			//name = EngineLightEffect
+			%enableEmissiveLight = false // engines with no emissive will shut this off automatically
+			%engineEmissiveMultiplier = 1 // 1.33 //scale emissive brightness
+			%jitterMultiplier = 0.5 //0.1 // controls main engine light flicker intensity
+			%lightFadeCoefficient = 0.7
+			%lightPower = .25
+			%lightRange = 3 // 9.0 small engine
+
+			%multiplierOnIva = .25 //  0.5 ? // scale main engine brightness when in IVA
+
+			// main engine light colour
+			%exhaustRed = 1 //
+      %exhaustGreen = 0.5 //0.55 //
+      %exhaustBlue = 0.5 //
+
+			%emissiveOffsetZ = #$../node_stack_bottom[1]$
+			@emissiveOffsetZ *=-0.67
+			%exhaustOffsetZ = #$../node_stack_bottom[1]$
+		 @exhaustOffsetZ *= -1.1
+	}
 }
 @PART[mpdt-0625]:AFTER[EngineLight]
 {
-	!MODULE[EngineLightEffect] {}
+	@MODULE[EngineLightEffect]
+	{
+			//name = EngineLightEffect
+			%enableEmissiveLight = false // engines with no emissive will shut this off automatically
+			%engineEmissiveMultiplier = 1 // 1.33 //scale emissive brightness
+			%jitterMultiplier = 0.5 //0.1 // controls main engine light flicker intensity
+			%lightFadeCoefficient = 0.7
+			%lightPower = .25
+			%lightRange = 3 // 9.0 small engine
+
+			%multiplierOnIva = .25 //  0.5 ? // scale main engine brightness when in IVA
+
+			// main engine light colour
+			%exhaustRed = 1 //
+      %exhaustGreen = 0.5 //0.55 //
+      %exhaustBlue = 0.5 //
+
+			%emissiveOffsetZ = #$../node_stack_bottom[1]$
+			@emissiveOffsetZ *=-0.67
+			%exhaustOffsetZ = #$../node_stack_bottom[1]$
+		 @exhaustOffsetZ *= -1.1
+	}
 }
+
+
+//Cannot handle multimode plume switching correctly. Used a blue colour with a hint of purple. Best balance I could find between xenon and argon plumes
 
 @PART[vasimr-25]:AFTER[EngineLight]
 {
-	!MODULE[EngineLightEffect] {}
+	@MODULE[EngineLightEffect]
+	{
+			//name = EngineLightEffect
+			%enableEmissiveLight = false // engines with no emissive will shut this off automatically
+			%engineEmissiveMultiplier = 1 // 1.33 //scale emissive brightness
+			%jitterMultiplier = 0.5 //0.1 // controls main engine light flicker intensity
+			%lightFadeCoefficient = 0.7
+			%lightPower = .25
+			%lightRange = 3 // 9.0 small engine
+
+			%multiplierOnIva = .25 //  0.5 ? // scale main engine brightness when in IVA
+
+			// main engine light colour
+			%exhaustRed = 0.6 //
+      %exhaustGreen = 0.6 //0.55 //
+      %exhaustBlue = 1 //
+
+			%emissiveOffsetZ = #$../node_stack_bottom[1]$
+			@emissiveOffsetZ *=-0.67
+			%exhaustOffsetZ = #$../node_stack_bottom[1]$
+		 @exhaustOffsetZ *= -1.1
+	}
 }
 @PART[vasimr-125]:AFTER[EngineLight]
 {
-	!MODULE[EngineLightEffect] {}
+	@MODULE[EngineLightEffect]
+	{
+			//name = EngineLightEffect
+			%enableEmissiveLight = false // engines with no emissive will shut this off automatically
+			%engineEmissiveMultiplier = 1 // 1.33 //scale emissive brightness
+			%jitterMultiplier = 0.5 //0.1 // controls main engine light flicker intensity
+			%lightFadeCoefficient = 0.7
+			%lightPower = .25
+			%lightRange = 3 // 9.0 small engine
+
+			%multiplierOnIva = .25 //  0.5 ? // scale main engine brightness when in IVA
+
+			// main engine light colour
+			%exhaustRed = 0.6 //
+      %exhaustGreen = 0.6 //0.55 //
+      %exhaustBlue = 1 //
+
+			%emissiveOffsetZ = #$../node_stack_bottom[1]$
+			@emissiveOffsetZ *=-0.67
+			%exhaustOffsetZ = #$../node_stack_bottom[1]$
+		 @exhaustOffsetZ *= -1.1
+	}
 }
 @PART[vasimr-0625]:AFTER[EngineLight]
 {
-	!MODULE[EngineLightEffect] {}
+	@MODULE[EngineLightEffect]
+	{
+			//name = EngineLightEffect
+			%enableEmissiveLight = false // engines with no emissive will shut this off automatically
+			%engineEmissiveMultiplier = 1 // 1.33 //scale emissive brightness
+			%jitterMultiplier = 0.5 //0.1 // controls main engine light flicker intensity
+			%lightFadeCoefficient = 0.7
+			%lightPower = .25
+			%lightRange = 3 // 9.0 small engine
+
+			%multiplierOnIva = .25 //  0.5 ? // scale main engine brightness when in IVA
+
+			// main engine light colour
+			%exhaustRed = 0.6 //
+      %exhaustGreen = 0.6 //0.55 //
+      %exhaustBlue = 1 //
+
+			%emissiveOffsetZ = #$../node_stack_bottom[1]$
+			@emissiveOffsetZ *=-0.67
+			%exhaustOffsetZ = #$../node_stack_bottom[1]$
+		 @exhaustOffsetZ *= -1.1
+	}
 }


### PR DESCRIPTION
Tried to match the plume colours and make them not too bright since they are electric engines.

VASIMIR is tricky since its multimode, I settled for a blue with a slight purple tint. Its not ideal but it doesnt look terrible with either xenon or argon plumes.

![screenshot69](https://user-images.githubusercontent.com/39182212/67488699-ae7eaa80-f689-11e9-9fcb-ca07fa2e65c3.png)
