### PR TITLE
Update NFPropulsionTweakPatch.cfg to remove interaction with NF Spacecraft

### DIFF
--- a/GameData/NearFuturePropulsion/Patches/NFPropulsionTweakPatch.cfg
+++ b/GameData/NearFuturePropulsion/Patches/NFPropulsionTweakPatch.cfg
@@ -124,7 +124,7 @@ NearFutureCustomSettings {
 	}
 }
 
-@PART[rcsblock-*]:AFTER[NearFuturePropulsion]
+@PART[rcsblock-gridded*,rcsblock-hall*,rcsblock-mpdt*,rcsblock-pulsedplasma*]:AFTER[NearFuturePropulsion]
 {
 	@MODULE[ModuleRCSFX],*
 	{


### PR DESCRIPTION
Adjust tweak patch to only target RCS parts in NF Propulsion.

Previous tweak patch affect all RCS parts with prefix "rcsblock". This unfortunately include monoprop RCS thrusters from NF Spacecraft, which should not be affected if I only wish to change ion RCS performance from NF Propulsion.